### PR TITLE
libaec 1.1.3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,5 +13,5 @@ cmake -LAH -G "Ninja"                                                     ^
 
 if errorlevel 1 exit 1
 
-ninja install
+ninja install -j%CPU_COUNT%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 mkdir build && cd build
 
-cmake \
+cmake ${CMAKE_ARGS} \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_INCLUDEDIR=include \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libaec" %}
-{% set version = "1.0.4" %}
+{% set version = "1.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://gitlab.dkrz.de/k202009/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: 7d85784afc0c4d82adae2d3a1ad2c0a9db700a49ad8f32674618b0089206cb5e
+  sha256: 1bafbfaef773bf8f5e5451e6c1f23da36c7199186cc0974fb9874bf723fe4270
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win and vc<14]
   run_exports:
   - {{ pin_subpackage('libaec') }}
@@ -27,18 +27,21 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libaec${SHLIB_EXT}        # [not win]
     - test -f ${PREFIX}/lib/libsz${SHLIB_EXT}         # [not win]
+    - test -f ${PREFIX}/include/libaec.h              # [not win]
+    - test -f ${PREFIX}/include/szlib.h               # [not win]
     - if not exist %LIBRARY_LIB%\\aec.lib exit 1      # [win]
     - if not exist %LIBRARY_BIN%\\aec.dll exit 1      # [win]
     - if not exist %LIBRARY_LIB%\\szip.lib exit 1     # [win]
     - if not exist %LIBRARY_BIN%\\szip.dll exit 1     # [win]
     - if not exist %LIBRARY_INC%\\libaec.h exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\szlib.h exit 1      # [win]
 
 about:
   home: https://gitlab.dkrz.de/k202009/libaec
   license: BSD-2-Clause
   license_family: BSD
-  license_file: Copyright.txt
-  summary: 'Adaptive Entropy Coding library'
+  license_file: LICENSE.txt
+  summary: Adaptive Entropy Coding library
   description: |
     Libaec provides fast lossless compression of 1 up to 32 bit wide signed or unsigned integers (samples).
     The library achieves best results for low entropy data as often encountered in space imaging instrument
@@ -47,6 +50,7 @@ about:
     Libaec implements Golomb-Rice coding as defined in the Space Data System Standard documents 121.0-B-2
     and 120.0-G-2.
   dev_url: https://gitlab.dkrz.de/k202009/libaec
+  doc_url: https://gitlab.dkrz.de/k202009/libaec
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6426](https://anaconda.atlassian.net/browse/PKG-6426) 
- [Upstream repository](https://gitlab.dkrz.de/k202009/libaec/-/tree/v1.1.3?ref_type=tags)
- Requirements:
  - https://gitlab.dkrz.de/k202009/libaec/-/blob/v1.1.3/CMakeLists.txt?ref_type=tags
  -  https://gitlab.dkrz.de/k202009/libaec/-/blob/v1.1.3/configure.ac?ref_type=tags

### Explanation of changes:

- Add more test commands
- Update the license filename
- Add doc_url

### Notes:

- imagecodecs 2024.9.22 requires it https://github.com/AnacondaRecipes/imagecodecs-feedstock/pull/17

[PKG-6426]: https://anaconda.atlassian.net/browse/PKG-6426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ